### PR TITLE
Enable cross-origin HTTP request.

### DIFF
--- a/pcdm2manifest.rb
+++ b/pcdm2manifest.rb
@@ -355,6 +355,7 @@ configure do
 end
 
 get '/manifests/:id' do
+  headers 'Access-Control-Allow-Origin' => '*'
   content_type :json
   generate_issue_manifest(FCREPO_BASE_URI + params[:id]).to_json
 end


### PR DESCRIPTION
I ran into CORS problem on my local environment, so I've added this line to let sinatra allow cross-origin request for manifest generation.
